### PR TITLE
Change block-wip-pr ubuntu version to latest

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR Checks
 on: [pull_request]
 jobs:
   block-wip-pr:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.0.0
     - name: Block WIP PR


### PR DESCRIPTION
### CHANGELOG

- Change block-wip-pr ubuntu version to always use the latest version

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none
